### PR TITLE
hotfix env pip isntall

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,8 +21,8 @@ dependencies:
   - nbconvert
   - pip
   - pip:
-       - e ./dependencies/flopy
-       - e ./dependencies/pyemu
+       - -e ./dependencies/flopy
+       - -e ./dependencies/pyemu
        - pypestutils == 0.3.0
 
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the `environment.yml` file, specifically correcting the syntax for editable installs in the dependencies list. The change ensures that the `flopy` and `pyemu` packages are installed in editable mode as intended.

* Fixed the formatting for editable installs of `flopy` and `pyemu` in the `pip` section of `environment.yml` by adding a leading dash to each entry.